### PR TITLE
Update to gles3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
-/target
+target/
+.idea/
 Cargo.lock

--- a/build.rs
+++ b/build.rs
@@ -73,7 +73,11 @@ fn main() {
 
     let project_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
     println!("cargo:rustc-link-search={}", project_dir); // the "-L" flag
-    println!("cargo:rustc-link-lib=GLESv3"); // the "-l" flag
+    if std::env::var("CARGO_CFG_TARGET_OS") == Ok("linux".into()) {
+        println!("cargo:rustc-link-lib=GLESv2"); // the "-l" flag
+    } else if std::env::var("CARGO_CFG_TARGET_OS") == Ok("android".into()) {
+        println!("cargo:rustc-link-lib=GLESv3"); // the "-l" flag
+    }
     println!("cargo:rustc-link-lib=c"); // the "-l" flag
 
     rebuild();

--- a/build.rs
+++ b/build.rs
@@ -73,7 +73,7 @@ fn main() {
 
     let project_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
     println!("cargo:rustc-link-search={}", project_dir); // the "-L" flag
-    println!("cargo:rustc-link-lib=GLESv2"); // the "-l" flag
+    println!("cargo:rustc-link-lib=GLESv3"); // the "-l" flag
     println!("cargo:rustc-link-lib=c"); // the "-l" flag
 
     rebuild();


### PR DESCRIPTION
While attempting to use this crate, we observed that trying to call `glGenVertexArrays()` failed with a link error. By changing:

```
println!("cargo:rustc-link-lib=GLESv2")
```

to 

```
println!("cargo:rustc-link-lib=GLESv3")
```

It resolved our issue. If that isn't correct we'd be happy to look into making it conditional based on a feature or some other mechanism.

Thanks for making this crate!

- Brent